### PR TITLE
Add ASCII graph option

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Run the abstraction level analyzer with a text file:
 python abstract_level_analyzer.py input.txt
 ```
 
+Pass `--graph` to display a simple ASCII chart of abstraction levels.
+
 Set your OpenAI API key in the `OPENAI_API_KEY` environment variable. The
 `openai` package must be installed for the analyzer to work.
 


### PR DESCRIPTION
## Summary
- show a simple ASCII graph for sentence abstraction levels
- document `--graph` option

## Testing
- `python -m unittest discover -s tests`

------
https://chatgpt.com/codex/tasks/task_e_683d0b6bba38832daa183d9858346fe1